### PR TITLE
fix method-CTOpenSSLSymmetricEncrypt CTOpenSSLCipherAES256  parameter

### DIFF
--- a/CTOpenSSLWrapper/CTOpenSSLWrapperTests/CTOpenSSLWrapperTests.m
+++ b/CTOpenSSLWrapper/CTOpenSSLWrapperTests/CTOpenSSLWrapperTests.m
@@ -19,9 +19,14 @@
     NSString *stringToBeDecrypted = @"SecretString";
     NSData *rawData = [stringToBeDecrypted dataUsingEncoding:NSUTF8StringEncoding];
     
-    NSData *encryptedData = CTOpenSSLSymmetricEncrypt(CTOpenSSLCipherAES256, symmetricKeyData, rawData);
-    NSData *decryptedData = CTOpenSSLSymmetricDecrypt(CTOpenSSLCipherAES256, symmetricKeyData, encryptedData);
+    NSData *encryptedData = nil;
+    NSData *decryptedData = nil;
+    BOOL isSuccess = CTOpenSSLSymmetricEncrypt(CTOpenSSLCipherAES256, symmetricKeyData, rawData, &encryptedData);
+    STAssertTrue(isSuccess, @"encrypted is not success");
     STAssertNotNil(encryptedData, @"encrypted data cannot be nil");
+    
+    isSuccess = CTOpenSSLSymmetricDecrypt(CTOpenSSLCipherAES256, symmetricKeyData, encryptedData, &decryptedData);
+    STAssertTrue(isSuccess, @"decrypted is not success");
     STAssertFalse([encryptedData isEqual:decryptedData], @"encryptedData and decryptedData cannot be the same");
     
     NSString *decryptedString = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Hello , I find the TESTS for AES256 parameter is wrong when I use it . I try to fix it .Now it works . 
Thank you for the great wrapper .
