### PR TITLE
Use a different padding for RSA

### DIFF
--- a/CTOpenSSLWrapper/CTOpenSSLWrapper/CTOpenSSLAsymmetricEncryption/CTOpenSSLAsymmetricEncryption.h
+++ b/CTOpenSSLWrapper/CTOpenSSLWrapper/CTOpenSSLAsymmetricEncryption/CTOpenSSLAsymmetricEncryption.h
@@ -34,12 +34,30 @@ NSData *CTOpenSSLExtractPublicKeyFromPrivateRSAKey(NSData *privateKeyData);
 NSData *CTOpenSSLRSAEncrypt(NSData *publicKeyData, NSData *data);
 
 /**
+ @abstract  encrypts data asymmetrically
+ @param     publicKeyData: data representing the public key
+ @param     data: data to be encrypted
+ @param     padding: RSA Padding type
+ @return    encrypted data
+ */
+NSData *CTOpenSSLRSAEncryptWithPadding(NSData *publicKeyData, NSData *data, int padding);
+
+/**
  @abstract  decrypts data asymmetrically
  @param     privateKeyData: data representing the private key
  @param     data: data to be decrypted
  @return    dectryped data
  */
 NSData *CTOpenSSLRSADecrypt(NSData *privateKeyData, NSData *data);
+
+/**
+ @abstract  decrypts data asymmetrically
+ @param     privateKeyData: data representing the private key
+ @param     data: data to be decrypted
+ @param     padding: RSA Padding type
+ @return    dectryped data
+ */
+NSData *CTOpenSSLRSADecryptWithPadding(NSData *privateKeyData, NSData *data, int padding);
 
 /**
  @abstract  generates signature of data with privateKeyData.

--- a/CTOpenSSLWrapper/CTOpenSSLWrapper/CTOpenSSLAsymmetricEncryption/CTOpenSSLAsymmetricEncryption.m
+++ b/CTOpenSSLWrapper/CTOpenSSLWrapper/CTOpenSSLAsymmetricEncryption/CTOpenSSLAsymmetricEncryption.m
@@ -95,6 +95,11 @@ NSData *CTOpenSSLExtractPublicKeyFromPrivateRSAKey(NSData *privateKeyData)
 
 NSData *CTOpenSSLRSAEncrypt(NSData *publicKeyData, NSData *data)
 {
+	return CTOpenSSLRSAEncryptWithPadding(publicKeyData, data, RSA_PKCS1_PADDING);
+}
+
+NSData *CTOpenSSLRSAEncryptWithPadding(NSData *publicKeyData, NSData *data, int padding)
+{
     CTOpenSSLInitialize();
 
     unsigned char *inputBytes = (unsigned char *)data.bytes;
@@ -114,7 +119,7 @@ NSData *CTOpenSSLRSAEncrypt(NSData *publicKeyData, NSData *data)
     unsigned char *outputBuffer = (unsigned char *)malloc(RSA_size(publicRSA));
     int outputLength = 0;
 
-    if (!(outputLength = RSA_public_encrypt((int)inputLength, inputBytes, (unsigned char *)outputBuffer, publicRSA, RSA_PKCS1_PADDING))) {
+    if (!(outputLength = RSA_public_encrypt((int)inputLength, inputBytes, (unsigned char *)outputBuffer, publicRSA, padding))) {
         [NSException raise:NSInternalInconsistencyException format:@"RSA public encryption RSA_public_encrypt() failed"];
     }
 
@@ -131,6 +136,11 @@ NSData *CTOpenSSLRSAEncrypt(NSData *publicKeyData, NSData *data)
 }
 
 NSData *CTOpenSSLRSADecrypt(NSData *privateKeyData, NSData *data)
+{
+	return CTOpenSSLRSADecryptWithPadding(privateKeyData, data, RSA_PKCS1_PADDING);
+}
+
+NSData *CTOpenSSLRSADecryptWithPadding(NSData *privateKeyData, NSData *data, int padding)
 {
     CTOpenSSLInitialize();
 
@@ -156,7 +166,7 @@ NSData *CTOpenSSLRSADecrypt(NSData *privateKeyData, NSData *data)
     unsigned char *outputBuffer = (unsigned char *)malloc(RSA_size(privateRSA));
     int outputLength = 0;
 
-    if (!(outputLength = RSA_private_decrypt((int)inputLength, inputBytes, outputBuffer, privateRSA, RSA_PKCS1_PADDING))) {
+    if (!(outputLength = RSA_private_decrypt((int)inputLength, inputBytes, outputBuffer, privateRSA, padding))) {
         [NSException raise:NSInternalInconsistencyException format:@"RSA private decrypt RSA_private_decrypt() failed"];
     }
 

--- a/CTOpenSSLWrapper/CTOpenSSLWrapperTests/CTOpenSSLWrapperTests.m
+++ b/CTOpenSSLWrapper/CTOpenSSLWrapperTests/CTOpenSSLWrapperTests.m
@@ -34,6 +34,8 @@
     STAssertEqualObjects(stringToBeDecrypted, decryptedString, @"string before and after symmetric encryption must be the same");
 }
 
+#define RSA_PKCS1_OAEP_PADDING 4
+
 - (void)testAsymmetricEncryption
 {
     NSData *privateKeyData = CTOpenSSLGeneratePrivateRSAKey(1024, CTOpenSSLPrivateKeyFormatPEM);
@@ -54,7 +56,18 @@
     
     NSString *decryptedString = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
     STAssertEqualObjects(stringToBeDecrypted, decryptedString, @"string before and after asymmetric encryption must be the same");
+
+	NSData *encryptedDataWithPadding = CTOpenSSLRSAEncryptWithPadding(publicKeyData, rawData, RSA_PKCS1_OAEP_PADDING);
+	STAssertNotNil(encryptedDataWithPadding, @"encrypted data cannot be nil");
+	STAssertFalse([rawData isEqualToData:encryptedDataWithPadding], @"CTOpenSSLAsymmetricEncrypt cannot return unencrypted data");
+
+	NSData *decryptedDataWithPadding = CTOpenSSLRSADecryptWithPadding(privateKeyData, encryptedDataWithPadding, RSA_PKCS1_OAEP_PADDING);
+	STAssertNotNil(decryptedDataWithPadding, @"decrypted data cannot be nil");
+
+	NSString *decryptedStringWithPadding = [[NSString alloc] initWithData:decryptedDataWithPadding encoding:NSUTF8StringEncoding];
+	STAssertEqualObjects(stringToBeDecrypted, decryptedStringWithPadding, @"string before and after asymmetric encryption must be the same");
 }
+
 
 - (void)testDigestGeneration
 {


### PR DESCRIPTION
For one of my projects I needed to alter the default RSA padding from RSA_PKCS1_PADDING to RSA_PKCS1_OAEP_PADDING.

This pull request contains two new functions (and a test) to accomplish that. I've also altered the default RSA decrypt and encrypt function to use the new functions with a RSA_PKCS1_PADDING type padding. 

The RSA padding types were already located in the openssl/rsa.h
